### PR TITLE
doc(readme): filtering watched repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ For maintained binaries and/or more info:
 - [Latest iOS version](https://itunes.apple.com/US/app/id806104975?mt=8)
 
 - [Trailer for Android](https://github.com/amencarini/droidtrailer)
+
+Note: Only watched repositories will be listed. To reduce notification noise open Trailer > Preferences to change the display settings of each repository. To change the settings for all visible repositories use "set all PR…" and "Set all issues…". Filter first to only modify a sub set of repositories.


### PR DESCRIPTION
I was wondering how to get repositories into the visible list but couldn't see how until I saw https://github.com/ptsochantaris/trailer/issues/107 and the discussion at https://github.com/ptsochantaris/trailer/issues/108. I thought it might be helpful to include a note in the readme and the pages.
